### PR TITLE
Botón de información y slider de películas

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -150,7 +150,7 @@ const showData = (menuItems) =>{
                 <div class="description">
                 <p>${movie.description.split(".", 1)}</p>
                 </div>
-                <a class="btn-mas">See more</a>
+                <a class="btn-mas">More Details</a>
             </div>
         </div>
     </article>

--- a/src/main.js
+++ b/src/main.js
@@ -150,7 +150,7 @@ const showData = (menuItems) =>{
                 <div class="description">
                 <p>${movie.description.split(".", 1)}</p>
                 </div>
-                <a class="btn-mas">More Details</a>
+                <a class="btn-mas">More details</a>
             </div>
         </div>
     </article>

--- a/src/style.css
+++ b/src/style.css
@@ -193,9 +193,6 @@ section.portada{
     animation: scroll 28s linear infinite;
     margin-bottom: 20px;
 }
-.slide-track:hover{
-    animation-play-state:paused ;
-}
 @keyframes scroll{
     0%{
         transform: translateX(0);
@@ -215,11 +212,7 @@ section.portada{
 .slide img{
     width: 100%;
     height: 100%;
-    transition: transform 1s;
     border-radius: 5px;
-}
-.slide img:hover{
-    transform: translateZ(10px);
 }
 
 .slider::before,


### PR DESCRIPTION
-Se cambió en nombre del botón 'See more' a 'More details' para que fuese más descriptivo.
-Se quitó el efecto hover de las imagenes de los posters del segundo slider de la sección 'Home' para que no diera la sensación de que es un elemento clickeable.